### PR TITLE
feat: include Gmail link in copy and sort created receipts

### DIFF
--- a/src/app/api/receipts/search/route.ts
+++ b/src/app/api/receipts/search/route.ts
@@ -76,6 +76,23 @@ export async function GET(request: NextRequest) {
       accessToken: accessToken,
     };
 
+    // Get the connected Gmail account's email address for authuser param
+    let gmailAccountEmail: string | null = null;
+    try {
+      const profileResponse = await fetch(
+        "https://gmail.googleapis.com/gmail/v1/users/me/profile",
+        {
+          headers: { Authorization: `Bearer ${accessToken}` },
+        }
+      );
+      if (profileResponse.ok) {
+        const profileData = await profileResponse.json();
+        gmailAccountEmail = profileData.emailAddress;
+      }
+    } catch (err) {
+      console.warn("Failed to fetch Gmail profile:", err);
+    }
+
     // Initialize service registry
     const serviceRegistry = new ServiceRegistry();
     serviceRegistry.registerService(ServiceType.UBER, new UberService());
@@ -113,6 +130,7 @@ export async function GET(request: NextRequest) {
                 pickupTime,
                 dropoffTime,
                 pdfUrl,
+                emailId,
                 service: serviceName,
                 serviceId,
                 driverName,
@@ -130,6 +148,11 @@ export async function GET(request: NextRequest) {
                 pickupTime,
                 dropoffTime,
                 pdfUrl,
+                gmailUrl: gmailAccountEmail
+                  ? `https://mail.google.com/mail/?authuser=${encodeURIComponent(
+                      gmailAccountEmail
+                    )}#all/${emailId}`
+                  : `https://mail.google.com/mail/u/0/#all/${emailId}`,
                 service: serviceName,
                 serviceId,
                 driverName,

--- a/src/app/components/ActionButtons.tsx
+++ b/src/app/components/ActionButtons.tsx
@@ -65,6 +65,7 @@ export default function ActionButtons({
       "Drop Location",
       "Pick Up Time",
       "Drop Time",
+      "Email",
     ].join("\t");
 
     // Format each receipt as a tab-separated row
@@ -76,6 +77,7 @@ export default function ActionButtons({
         receipt.dropoffLocation || "",
         receipt.pickupTime || "",
         receipt.dropoffTime || "",
+        receipt.gmailUrl || "",
       ].join("\t");
     });
 
@@ -86,7 +88,7 @@ export default function ActionButtons({
     );
 
     // Add total row
-    const totalRow = ["TOTAL", totalAmount, "", "", "", ""].join("\t");
+    const totalRow = ["TOTAL", totalAmount, "", "", "", "", ""].join("\t");
 
     // Combine headers, data rows, and total row
     const copyText = [headers, ...rows, "", totalRow].join("\n");

--- a/src/app/components/ReceiptsTable.tsx
+++ b/src/app/components/ReceiptsTable.tsx
@@ -55,6 +55,11 @@ export default function ReceiptsTable({
       sortable: true,
     },
     { key: "dropoffTime" as keyof Receipt, name: "Drop Time", sortable: true },
+    {
+      key: "gmailUrl" as keyof Receipt,
+      name: "Email",
+      sortable: false,
+    },
   ];
 
   // Handle column header click for sorting
@@ -139,6 +144,9 @@ export default function ReceiptsTable({
                   </TableCell>
                   <TableCell>
                     <div className="h-4 w-16 bg-muted rounded animate-pulse"></div>
+                  </TableCell>
+                  <TableCell>
+                    <div className="h-4 w-4 bg-muted rounded animate-pulse"></div>
                   </TableCell>
                   <TableCell className="text-right">
                     <div className="h-8 w-24 bg-muted rounded animate-pulse ml-auto"></div>
@@ -239,6 +247,25 @@ export default function ReceiptsTable({
                   </TableCell>
                   <TableCell>{receipt.pickupTime || ""}</TableCell>
                   <TableCell>{receipt.dropoffTime || ""}</TableCell>
+                  <TableCell className="text-center">
+                    {receipt.gmailUrl && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-9 px-3 py-2"
+                        asChild
+                      >
+                        <a
+                          href={receipt.gmailUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          aria-label="View email in Gmail"
+                        >
+                          <i className="bx bxl-gmail"></i>
+                        </a>
+                      </Button>
+                    )}
+                  </TableCell>
                   <TableCell className="text-right">
                     <Button
                       variant="ghost"

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -12,6 +12,7 @@ export interface Receipt {
   pickupTime?: string;
   dropoffTime?: string;
   pdfUrl?: string; // PDF download link from email
+  gmailUrl?: string; // Direct link to view the email in Gmail
   service: string; // NEW: Which service (Uber, Rapido, etc.)
   serviceId?: string; // NEW: Service-specific ID (tripId, rideId)
   driverName?: string; // NEW: Driver information

--- a/src/lib/receiptUtils.ts
+++ b/src/lib/receiptUtils.ts
@@ -14,6 +14,13 @@ export function createReceiptFromSelection(
     selectedReceipts.includes(receipt.id)
   );
 
+  // Sort receipts by date in ascending order
+  const sortedReceiptObjects = selectedReceiptObjects
+    .slice()
+    .sort(
+      (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+    );
+
   if (selectedReceiptObjects.length === 0) {
     toast.error("No receipts selected");
     return;
@@ -23,7 +30,7 @@ export function createReceiptFromSelection(
   const headers = ["Date", "Amount"].join("\t");
 
   // Format each receipt with date logic (if pickup after 12 AM, use previous date)
-  const rows = selectedReceiptObjects.map((receipt) => {
+  const rows = sortedReceiptObjects.map((receipt) => {
     let receiptDate = new Date(receipt.date);
 
     // If pickup time is available and after midnight, use previous date
@@ -40,7 +47,7 @@ export function createReceiptFromSelection(
   });
 
   // Calculate total amount
-  const totalAmount = selectedReceiptObjects.reduce(
+  const totalAmount = sortedReceiptObjects.reduce(
     (sum, receipt) => sum + receipt.amount,
     0
   );


### PR DESCRIPTION
## Summary
- copy selected receipts with Gmail links
- sort receipts by date ascending when generating receipt output

## Testing
- `pnpm lint` *(fails: Key "rules": Key "@typescript-eslint/ban-types": Could not find "ban-types" in plugin "@typescript-eslint".)*

------
https://chatgpt.com/codex/tasks/task_e_68c13f00ae10832085b416fa99303604